### PR TITLE
Vectorised `str_replace_all` call inside `markdown_link`. 

### DIFF
--- a/R/rmarkdown.R
+++ b/R/rmarkdown.R
@@ -43,7 +43,7 @@
     i <- 1
     for (i in seq(along = pos)) {
         t_i <- text[pos[i]]
-        t_i <- stringr::str_replace_all(t_i, pattern, function(m) f(m))
+        t_i <- stringr::str_replace_all(t_i, pattern, function(m) sapply(m, f))
         text[pos[i]] <- t_i
     }
     text


### PR DESCRIPTION
This small fix prevents `markdown_link()` from breaking on newer versions of `stringr`.
`str_replace_all()` will accept a character vector as replacement instead of a single function. See https://github.com/tidyverse/stringr/issues/551